### PR TITLE
feat: Add Gaggle class implementation

### DIFF
--- a/ankicard.py
+++ b/ankicard.py
@@ -17,7 +17,8 @@ class AnkiCard:
     self.note_type = note_type
     self.deck = deck
     self.guid = guid
-
+  def __repr__(self):
+    return str(self.fields)
   @staticmethod
   def __generate_field_names(field_names, n_fields):
     if field_names:

--- a/ankicard.py
+++ b/ankicard.py
@@ -8,15 +8,15 @@ class AnkiCard:
   Permanent Reference [09 May 2023]:
   https://github.com/ankitects/anki-manual/blob/0aa372146d10e299631e361769f41533a6d4a417/src/importing.md?plain=1#L196-L220
   """
-  def __init__(self, fields, has_html=False, tags=None, field_names=None,
-               note_type=None, deck=None, guid=None):
+  def __init__(self, fields, has_html=False, tags_idx=None, field_names=None,
+               note_type_idx=None, deck_idx=None, guid_idx=None):
     self.has_html = has_html
-    self.tags = tags
+    self.tags_field_idx = tags_idx
     self.field_names = self.__generate_field_names(field_names, len(fields))
     self.fields = self.__generate_field_dict(self.field_names, fields)
-    self.note_type = note_type
-    self.deck = deck
-    self.guid = guid
+    self.note_type_field = note_type_idx
+    self.deck_field_idx = deck_idx
+    self.guid_field_idx = guid_idx
   def __repr__(self):
     return str(self.fields)
   @staticmethod

--- a/ankicard.py
+++ b/ankicard.py
@@ -21,13 +21,16 @@ class AnkiCard:
     return str(self.fields)
   @staticmethod
   def __generate_field_names(field_names, n_fields):
-    if field_names:
+    if field_names is None:
+      field_names = []
+    if len(field_names) == n_fields:
       return field_names
-    field_names = []
-    for idx in range(n_fields):
-      curr_field_name = f'Field{idx}'
-      field_names.append(curr_field_name)
-    return field_names
+    else:
+      range_start = len(field_names)
+      range_stop = n_fields
+      for idx in range(range_start, range_stop):
+        field_names.append(f'Field{idx}')
+      return field_names
 
   @staticmethod
   def __generate_field_dict(field_names, fields):

--- a/ankicard.py
+++ b/ankicard.py
@@ -13,7 +13,7 @@ class AnkiCard:
     self.has_html = has_html
     self.tags = tags
     self.field_names = self.__generate_field_names(field_names, len(fields))
-    self.fields = self.__generate_field_dict(field_names, fields)
+    self.fields = self.__generate_field_dict(self.field_names, fields)
     self.note_type = note_type
     self.deck = deck
     self.guid = guid

--- a/collection.py
+++ b/collection.py
@@ -9,9 +9,9 @@ class Collection:
   Handles deck construction and organisation.
   """
   def __init__(self, exported_file=None):
-    self.decks = self.__set_decks(exported_file)
+    self.decks = self.__generate_decks(exported_file)
 
-  def __set_decks(self, exported_file):
+  def __generate_decks(self, exported_file):
     if not exported_file:
       return []
     return self.parse_anki_export(exported_file)
@@ -56,4 +56,5 @@ class Collection:
     return decks
 
 if __name__ == '__main__':
-  pass
+  c = Collection('Selected Notes.txt')
+  c.print_decks()

--- a/collection.py
+++ b/collection.py
@@ -3,6 +3,7 @@ import csv
 import ankicard
 _ANKI_EXPORT_HEADER_SYMBOL = '#'
 _ANKI_EXPORT_HEADER_SEPARATOR_SYMBOL = ':'
+_ANKI_EXPORT_ENCODING = 'utf-8'
 class Collection:
   """
   Parser class for Anki exported files.
@@ -53,7 +54,7 @@ class Collection:
 
   def parse_anki_export(self, exported_file):
     decks = []
-    with open(exported_file, newline='', encoding='utf-8') as f:
+    with open(exported_file, newline='', encoding=_ANKI_EXPORT_ENCODING) as f:
       header = self.parse_txt_file_header(f)
       if header['separator'] == 'tab':
         deck = self.create_cards_from_tsv(f)

--- a/collection.py
+++ b/collection.py
@@ -15,6 +15,8 @@ class Collection:
     if not exported_file:
       return []
     return self.parse_anki_export(exported_file)
+  def add_deck(self, deck):
+    self.decks.append(deck)
 
   def print_decks(self):
     for num, deck in enumerate(self.decks, start=1):

--- a/collection.py
+++ b/collection.py
@@ -56,7 +56,3 @@ class Collection:
         deck = self.create_cards_from_tsv(f)
         decks.append(deck)
     return decks
-
-if __name__ == '__main__':
-  c = Collection('Selected Notes.txt')
-  c.print_decks()

--- a/collection.py
+++ b/collection.py
@@ -1,0 +1,59 @@
+"""Base class for collection, a class representing multiple Anki Decks."""
+import csv
+import ankicard
+_ANKI_EXPORT_HEADER_SYMBOL = '#'
+_ANKI_EXPORT_HEADER_SEPARATOR_SYMBOL = ':'
+class Collection:
+  """
+  Parser class for Anki exported files.
+  Handles deck construction and organisation.
+  """
+  def __init__(self, exported_file=None):
+    self.decks = self.__set_decks(exported_file)
+
+  def __set_decks(self, exported_file):
+    if not exported_file:
+      return []
+    return self.parse_anki_export(exported_file)
+
+  def print_decks(self):
+    for num, deck in enumerate(self.decks, start=1):
+      print(f'Deck {num}:')
+      for card in deck:
+        print(card)
+
+  @staticmethod
+  def parse_txt_file_header(f):
+    header_symbol = _ANKI_EXPORT_HEADER_SYMBOL
+    header_separator = _ANKI_EXPORT_HEADER_SEPARATOR_SYMBOL
+    header = {}
+    reader_pos = f.tell()
+    while f.read(1) == header_symbol:
+      line = f.readline()
+      setting, value = line.split(header_separator)
+      value = value.rstrip()
+      header[setting] = value
+      reader_pos = f.tell()
+    f.seek(reader_pos)
+    return header
+
+  @staticmethod
+  def create_cards_from_tsv(f):
+    cards = csv.reader(f, dialect='excel-tab')
+    deck = []
+    for card in cards:
+      card = ankicard.AnkiCard(card)
+      deck.append(card)
+    return deck
+
+  def parse_anki_export(self, exported_file):
+    decks = []
+    with open(exported_file, newline='', encoding='utf-8') as f:
+      header = self.parse_txt_file_header(f)
+      if header['separator'] == 'tab':
+        deck = self.create_cards_from_tsv(f)
+        decks.append(deck)
+    return decks
+
+if __name__ == '__main__':
+  pass

--- a/collection.py
+++ b/collection.py
@@ -17,6 +17,9 @@ class Collection:
     return self.parse_anki_export(exported_file)
   def add_deck(self, deck):
     self.decks.append(deck)
+  def add_deck_from_file(self, file):
+    deck = self.parse_anki_export(file)
+    self.add_deck(deck)
 
   def print_decks(self):
     for num, deck in enumerate(self.decks, start=1):

--- a/gaggle.py
+++ b/gaggle.py
@@ -10,12 +10,12 @@ class Gaggle:
   Handles deck construction and organisation.
   """
   def __init__(self, exported_file=None):
-    self.decks = self.__generate_decks(exported_file)
+    self.decks = self.__initialise_decks(exported_file)
 
-  def __generate_decks(self, exported_file):
+  def __initialise_decks(self, exported_file):
     if not exported_file:
       return []
-    return self.parse_anki_export(exported_file)
+    return [self.parse_anki_export(exported_file)]
   def add_deck(self, deck):
     self.decks.append(deck)
   def add_deck_from_file(self, file):
@@ -53,10 +53,9 @@ class Gaggle:
     return deck
 
   def parse_anki_export(self, exported_file):
-    decks = []
+    deck = []
     with open(exported_file, newline='', encoding=_ANKI_EXPORT_ENCODING) as f:
       header = self.parse_txt_file_header(f)
       if header['separator'] == 'tab':
         deck = self.create_cards_from_tsv(f)
-        decks.append(deck)
-    return decks
+    return deck

--- a/gaggle.py
+++ b/gaggle.py
@@ -13,9 +13,11 @@ class Gaggle:
     self.decks = self.__initialise_decks(exported_file)
 
   def __initialise_decks(self, exported_file):
+    initial_deck = []
     if not exported_file:
-      return []
-    return [self.parse_anki_export(exported_file)]
+      return initial_deck
+    initial_deck.append(self.parse_anki_export(exported_file))
+    return initial_deck
   def add_deck(self, deck):
     self.decks.append(deck)
   def add_deck_from_file(self, file):

--- a/gaggle.py
+++ b/gaggle.py
@@ -52,10 +52,10 @@ class Gaggle:
       deck.append(card)
     return deck
 
-  def parse_anki_export(self, exported_file):
+  def parse_anki_export(self, exported_file, field_names=None):
     deck = []
     with open(exported_file, newline='', encoding=_ANKI_EXPORT_ENCODING) as f:
       header = self.parse_txt_file_header(f)
       if header['separator'] == 'tab':
-        deck = self.create_cards_from_tsv(f)
+        deck = self.create_cards_from_tsv(f, field_names)
     return deck

--- a/gaggle.py
+++ b/gaggle.py
@@ -4,7 +4,7 @@ import ankicard
 _ANKI_EXPORT_HEADER_SYMBOL = '#'
 _ANKI_EXPORT_HEADER_SEPARATOR_SYMBOL = ':'
 _ANKI_EXPORT_ENCODING = 'utf-8'
-class Collection:
+class Gaggle:
   """
   Parser class for Anki exported files.
   Handles deck construction and organisation.

--- a/gaggle.py
+++ b/gaggle.py
@@ -1,9 +1,12 @@
 """Base class for collection, a class representing multiple Anki Decks."""
 import csv
 import ankicard
+
+
 _ANKI_EXPORT_HEADER_SYMBOL = '#'
 _ANKI_EXPORT_HEADER_SEPARATOR_SYMBOL = ':'
 _ANKI_EXPORT_ENCODING = 'utf-8'
+
 class Gaggle:
   """
   Parser class for Anki exported files.
@@ -18,8 +21,10 @@ class Gaggle:
       return initial_deck
     initial_deck.append(self.parse_anki_export(exported_file))
     return initial_deck
+
   def add_deck(self, deck):
     self.decks.append(deck)
+
   def add_deck_from_file(self, file):
     deck = self.parse_anki_export(file)
     self.add_deck(deck)

--- a/gaggle.py
+++ b/gaggle.py
@@ -44,11 +44,11 @@ class Gaggle:
     return header
 
   @staticmethod
-  def create_cards_from_tsv(f):
+  def create_cards_from_tsv(f, field_names=None):
     cards = csv.reader(f, dialect='excel-tab')
     deck = []
     for card in cards:
-      card = ankicard.AnkiCard(card)
+      card = ankicard.AnkiCard(card, field_names=field_names)
       deck.append(card)
     return deck
 

--- a/gaggle.py
+++ b/gaggle.py
@@ -37,11 +37,11 @@ def parse_anki_export(exported_file, field_names=None):
       deck = create_cards_from_tsv(f, field_names)
   return deck
 
-def _initialise_decks(exported_file):
+def _initialise_decks(exported_file, field_names):
   initial_deck = []
   if not exported_file:
     return initial_deck
-  initial_deck.append(parse_anki_export(exported_file))
+  initial_deck.append(parse_anki_export(exported_file, field_names))
   return initial_deck
 
 class Gaggle:
@@ -49,8 +49,8 @@ class Gaggle:
   Parser class for Anki exported files.
   Handles deck construction and organisation.
   """
-  def __init__(self, exported_file=None):
-    self.decks = _initialise_decks(exported_file)
+  def __init__(self, exported_file=None, field_names=None):
+    self.decks = _initialise_decks(exported_file, field_names)
 
   def add_deck(self, deck):
     self.decks.append(deck)


### PR DESCRIPTION
## What?
Add Gaggle class, a class representing a collection of Decks. 
## Why?
Contain functions necessary to import new decks and modify/view existing decks.
## How?
Parses exported files from Anki.
`parse_anki_export`
For a `Notes in Plaintext (.txt)` file from Anki, parse the header. 
`prase_txt_file_header`
Then convert the parsed header to `Gaggle` compliant format. 
`reformat_header_settings` `convert_ankicol_to_gagglecol`
Create `AnkiCard` from each line. 
`create_cards_from_tsv`
Populate `AnkiCard` variables with information from header. 
`create_cards_from_tsv`
Assign list of `AnkiCard` to class variable `self.decks`.
`__init__`

Seperate functionality:
Adding a deck directly to `self.decks`
`add_deck`
Adding a new deck from a file
`add_deck_from_file`
Print out the string representation of each item in `self.decks`. This does not create a string representation and pipes directly to console output.
`print_decks`
## Testing?
Testing done in scratch file. Each function run to ensure behaviour is consistent with intended implementation.

No issues found with  `Notes in Plaintext (.txt)` generated from Anki with all optional settings populated. Testing on non-compliant file types/structures not done.

## Anything Else?
Only `Notes in Plaintext (.txt)` file type is implemented currently. Requires further implementation of `.apkg` and `.colpkg`.

Need further testing on and error checking for poorly formatted files.

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>