### PR TITLE
feat: Implement Anki header support

### DIFF
--- a/ankicard.py
+++ b/ankicard.py
@@ -23,6 +23,7 @@ def _generate_field_dict(field_names, fields):
     field_dict[field_names[idx]] = fields[idx]
   return field_dict
 
+
 def _parse_bool(bool_as_str):
   if bool_as_str == _ANKI_HEADER_TRUE:
     return True

--- a/ankicard.py
+++ b/ankicard.py
@@ -64,5 +64,21 @@ class AnkiCard:
   def get_field(self, field_name):
     return self.fields[field_name]
 
+  def contains_html(self):
+    return self.has_html
+
+  def get_tags(self):
+    return self.get_field('Tags')
+
   def get_field_names(self):
     return self.field_names
+
+  def get_note_type(self):
+    return self.get_field('Note Type')
+
+  def get_deck_name(self):
+    return self.get_field('Deck')
+
+  def get_guid(self):
+    return self.get_field('GUID')
+

--- a/ankicard.py
+++ b/ankicard.py
@@ -32,7 +32,7 @@ class AnkiCard:
                note_type_idx=None, deck_idx=None, guid_idx=None):
     self.has_html = has_html
     self.tags_field_idx = tags_idx
-    self.note_type_field = note_type_idx
+    self.note_type_field_idx = note_type_idx
     self.deck_field_idx = deck_idx
     self.guid_field_idx = guid_idx
     self.field_names = _generate_field_names(field_names, len(fields))

--- a/ankicard.py
+++ b/ankicard.py
@@ -1,5 +1,9 @@
 """Base class for Anki card"""
 
+_ANKI_HEADER_TRUE = 'true'
+_ANKI_HEADER_FALSE = 'false'
+
+
 def _generate_field_names(field_names, n_fields):
   if field_names is None:
     field_names = []
@@ -19,6 +23,14 @@ def _generate_field_dict(field_names, fields):
     field_dict[field_names[idx]] = fields[idx]
   return field_dict
 
+def _parse_bool(bool_as_str):
+  if bool_as_str == _ANKI_HEADER_TRUE:
+    return True
+  elif bool_as_str == _ANKI_HEADER_FALSE:
+    return False
+  else:
+    return TypeError
+
 
 class AnkiCard:
   """
@@ -30,7 +42,7 @@ class AnkiCard:
   """
   def __init__(self, fields, has_html=False, tags_idx=None, field_names=None,
                note_type_idx=None, deck_idx=None, guid_idx=None):
-    self.has_html = has_html
+    self.has_html = _parse_bool(has_html)
     self.tags_field_idx = tags_idx
     self.note_type_field_idx = note_type_idx
     self.deck_field_idx = deck_idx

--- a/ankicard.py
+++ b/ankicard.py
@@ -32,14 +32,22 @@ class AnkiCard:
                note_type_idx=None, deck_idx=None, guid_idx=None):
     self.has_html = has_html
     self.tags_field_idx = tags_idx
-    self.field_names = _generate_field_names(field_names, len(fields))
-    self.fields = _generate_field_dict(self.field_names, fields)
     self.note_type_field = note_type_idx
     self.deck_field_idx = deck_idx
     self.guid_field_idx = guid_idx
+    self.field_names = _generate_field_names(field_names, len(fields))
+    anki_header_names = {'Tags':tags_idx, 'Deck':deck_idx,
+                         'Note Type':note_type_idx, 'GUID':guid_idx}
+    self._overlay_anki_header_names(anki_header_names)
+    self.fields = _generate_field_dict(self.field_names, fields)
 
   def __repr__(self):
     return str(self.fields)
+
+  def _overlay_anki_header_names(self, anki_header_names):
+    for name, field_idx in anki_header_names.items():
+      if field_idx:
+        self.field_names[field_idx] = name
 
   def get_field(self, field_name):
     return self.fields[field_name]


### PR DESCRIPTION
## What?
Implement support for field names defined in the Anki header
## Why?
Allow header naming without explicitly being set
## How?
When defined, assign Gaggle defiend name of each Anki header setting to the corresponding `field_idx`.
## Testing?
Testing conducted in scratch file. Used well-formed, format-following files.

## Anything Else?
Requires explcit handling of error cases. Currently defaults to raising `KeyError` as defined by `collections.Dict`.

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>