### PR TITLE
PyCharm update

### DIFF
--- a/.idea/Gaggle.iml
+++ b/.idea/Gaggle.iml
@@ -12,6 +12,7 @@
       <excludePattern pattern="poetry.lock" />
       <excludePattern pattern="pyproject.toml" />
       <excludePattern pattern="README.md" />
+      <excludePattern pattern="LICENSE" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />


### PR DESCRIPTION
## What?
Exclude project license from project files.
## Why?
File should not be refactored
## How?
Add `LICENSE` to `Gaggle.iml`
## Testing?
File excluded as expected in clean install
## Screenshots (optional)
0
## Anything Else?
0
<!---
Copyright 2023 The Gaggle Authors. All Rights Reserved.

This file is part of Gaggle.

Gaggle is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.

Gaggle is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.

You should have received a copy of the GNU General Public License along with Gaggle. If not, see <https://www.gnu.org/licenses/>.
--->

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>