### PR TITLE
test: Add unit test for CardsNotWrittenException

### DIFF
--- a/.idea/Gaggle.iml
+++ b/.idea/Gaggle.iml
@@ -2,6 +2,7 @@
 <module version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/.github" />
       <excludeFolder url="file://$MODULE_DIR$/.idea" />
       <excludeFolder url="file://$MODULE_DIR$/venv" />

--- a/.idea/Gaggle.iml
+++ b/.idea/Gaggle.iml
@@ -18,8 +18,14 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
+  <component name="PackageRequirementsSettings">
+    <option name="requirementsPath" value="" />
+  </component>
   <component name="PyDocumentationSettings">
     <option name="format" value="GOOGLE" />
     <option name="myDocStringFormat" value="Google" />
+  </component>
+  <component name="TestRunnerService">
+    <option name="PROJECT_TEST_RUNNER" value="py.test" />
   </component>
 </module>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ pytest = "^7.3.1"
 addopts = [
     "--import-mode=importlib",
 ]
+pythonpath = "src"
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/gaggle/ankicard.py
+++ b/src/gaggle/ankicard.py
@@ -23,6 +23,7 @@ _ANKI_HEADER_TRUE = 'true'
 _ANKI_HEADER_FALSE = 'false'
 
 T = TypeVar('T')
+S = TypeVar('S')
 class SupportsWriteRow(Protocol[T]):
   @property
   def dialect(self) -> Dialect: ...
@@ -55,9 +56,9 @@ def _generate_field_names(field_names, n_fields):
     return field_names
 
 
-def _generate_field_dict(field_names: Iterable,
-                         fields: Iterable,
-                         ) -> OrderedDict[str, str]:
+def _generate_field_dict(field_names: Iterable[T],
+                         fields: Iterable[S],
+                         ) -> OrderedDict[T, S]:
   """Create a dictionary mapping given names to a value in AnkiCard.
 
   Args:

--- a/src/gaggle/gaggle.py
+++ b/src/gaggle/gaggle.py
@@ -25,8 +25,8 @@ import enum
 from typing import overload, Any, List, Protocol, Self, TypeVar, Dict, Tuple, TYPE_CHECKING, Union
 from collections.abc import Iterable, Iterator, Sized
 
-from src.gaggle import exceptions
-from src.gaggle import ankicard
+from gaggle import exceptions
+from gaggle import ankicard
 
 if TYPE_CHECKING:
   from _typeshed import SupportsWrite, StrOrBytesPath, SupportsReadline, SupportsRead

--- a/tests/test_exceptions/test_exceptions.py
+++ b/tests/test_exceptions/test_exceptions.py
@@ -16,3 +16,10 @@
 # pylint: disable=missing-module-docstring
 # pylint: disable=missing-class-docstring
 # pylint: disable=redefined-outer-name
+import pytest
+from gaggle import exceptions
+
+
+@pytest.fixture
+def deck_index():
+  return 42

--- a/tests/test_exceptions/test_exceptions.py
+++ b/tests/test_exceptions/test_exceptions.py
@@ -39,3 +39,9 @@ class TestDecksNotWrittenException:
   def test_decks_not_written_exception_init_with_int(self):
     assert self.test_exception
 
+  def test_decks_not_written_exception_last_deck_written_property(
+      self,
+      deck_index
+  ):
+    assert self.test_exception.last_deck_written == deck_index
+

--- a/tests/test_exceptions/test_exceptions.py
+++ b/tests/test_exceptions/test_exceptions.py
@@ -26,4 +26,8 @@ def deck_index():
 
 
 class TestDecksNotWrittenException:
-  pass
+  @pytest.fixture(autouse=True)
+  def decks_not_written_exception(self, deck_index):
+    self.test_exception = exceptions.DecksNotWrittenException(deck_index)
+
+

--- a/tests/test_exceptions/test_exceptions.py
+++ b/tests/test_exceptions/test_exceptions.py
@@ -45,3 +45,9 @@ class TestDecksNotWrittenException:
   ):
     assert self.test_exception.last_deck_written == deck_index
 
+  def test_decks_not_written_exception_str(
+      self,
+      decks_not_written_exception_string_representation
+  ):
+    assert (str(self.test_exception) ==
+            decks_not_written_exception_string_representation)

--- a/tests/test_exceptions/test_exceptions.py
+++ b/tests/test_exceptions/test_exceptions.py
@@ -13,3 +13,6 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # Gaggle. If not, see <https://www.gnu.org/licenses/>.
+# pylint: disable=missing-module-docstring
+# pylint: disable=missing-class-docstring
+# pylint: disable=redefined-outer-name

--- a/tests/test_exceptions/test_exceptions.py
+++ b/tests/test_exceptions/test_exceptions.py
@@ -39,6 +39,10 @@ class TestDecksNotWrittenException:
   def test_decks_not_written_exception_init_with_int(self):
     assert self.test_exception
 
+  def test_decks_not_written_exception_init_with_none(self):
+    self.test_exception = exceptions.DecksNotWrittenException(None)
+    assert self.test_exception
+
   def test_decks_not_written_exception_last_deck_written_property(
       self,
       deck_index

--- a/tests/test_exceptions/test_exceptions.py
+++ b/tests/test_exceptions/test_exceptions.py
@@ -30,4 +30,9 @@ class TestDecksNotWrittenException:
   def decks_not_written_exception(self, deck_index):
     self.test_exception = exceptions.DecksNotWrittenException(deck_index)
 
+  @pytest.fixture
+  def decks_not_written_exception_string_representation(self, deck_index):
+    return (f'Failed to write all Decks to the file. '
+              f'Last deck successfully written was the deck at: '
+              f'Index {deck_index}')
 

--- a/tests/test_exceptions/test_exceptions.py
+++ b/tests/test_exceptions/test_exceptions.py
@@ -36,3 +36,6 @@ class TestDecksNotWrittenException:
               f'Last deck successfully written was the deck at: '
               f'Index {deck_index}')
 
+  def test_decks_not_written_exception_init_with_int(self):
+    assert self.test_exception
+

--- a/tests/test_exceptions/test_exceptions.py
+++ b/tests/test_exceptions/test_exceptions.py
@@ -23,3 +23,7 @@ from gaggle import exceptions
 @pytest.fixture
 def deck_index():
   return 42
+
+
+class TestDecksNotWrittenException:
+  pass

--- a/tests/test_gaggle/test_ankicard.py
+++ b/tests/test_gaggle/test_ankicard.py
@@ -13,3 +13,6 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # Gaggle. If not, see <https://www.gnu.org/licenses/>.
+# pylint: disable=missing-module-docstring
+# pylint: disable=missing-class-docstring
+# pylint: disable=redefined-outer-name

--- a/tests/test_gaggle/test_ankideck.py
+++ b/tests/test_gaggle/test_ankideck.py
@@ -13,3 +13,6 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # Gaggle. If not, see <https://www.gnu.org/licenses/>.
+# pylint: disable=missing-module-docstring
+# pylint: disable=missing-class-docstring
+# pylint: disable=redefined-outer-name

--- a/tests/test_gaggle/test_gaggle.py
+++ b/tests/test_gaggle/test_gaggle.py
@@ -13,3 +13,6 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # Gaggle. If not, see <https://www.gnu.org/licenses/>.
+# pylint: disable=missing-module-docstring
+# pylint: disable=missing-class-docstring
+# pylint: disable=redefined-outer-name


### PR DESCRIPTION
## What?
Add unit tests for `DecksNotWrittenException` from gaggle.exceptions
## Why?
Ensure components of `DecksNotWrittenException` work with future updates to the code base
## How?
Add fixtures to generate uniform `DecksNotWrittenException` for each test case.
Test __init__() with all accepted types
Test each property of `DecksNotWrittenException`
Test __str__() representation of `DecksNotWrittenException`
## Testing?
Unit tests pass
## Screenshots (optional)
0
## Anything Else?
Type hinting must be completed on Anki Card to write unit tests for bare minimum arguments.
<!---
Copyright 2023 The Gaggle Authors. All Rights Reserved.

This file is part of Gaggle.

Gaggle is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.

Gaggle is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.

You should have received a copy of the GNU General Public License along with Gaggle. If not, see <https://www.gnu.org/licenses/>.
--->

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>